### PR TITLE
Feature/29 detail inflate

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.5.1")
     implementation("com.google.android.material:material:1.4.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.window:window:1.0.0")
     addAndroidXDependencies()
     addNetworkDependencies()
     addNavigationDependencies()

--- a/app/src/main/java/com/angdroid/refrigerator_manament/data/datasource/home/UserInfoDataSource.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/data/datasource/home/UserInfoDataSource.kt
@@ -1,6 +1,5 @@
 package com.angdroid.refrigerator_manament.data.datasource.home
 
-import com.angdroid.refrigerator_manament.data.dto.UserDto
 import com.google.android.gms.tasks.Task
 import com.google.firebase.firestore.DocumentSnapshot
 

--- a/app/src/main/java/com/angdroid/refrigerator_manament/data/datasource/home/UserInfoDataSourceImpl.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/data/datasource/home/UserInfoDataSourceImpl.kt
@@ -4,8 +4,10 @@ import com.angdroid.refrigerator_manament.application.App
 import com.angdroid.refrigerator_manament.data.dto.FoodDto
 import com.angdroid.refrigerator_manament.data.dto.FoodInfoDto
 import com.angdroid.refrigerator_manament.data.dto.UserDto
+import com.google.android.gms.tasks.Task
+import com.google.firebase.firestore.DocumentSnapshot
 import javax.inject.Inject
 
 class UserInfoDataSourceImpl @Inject constructor() : UserInfoDataSource {
-    override suspend fun getUserInfo()= App.fireStoreUserReference.get()
+    override suspend fun getUserInfo() = App.fireStoreUserReference.get()
 }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/data/repository/FireBaseRepositoryImpl.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/data/repository/FireBaseRepositoryImpl.kt
@@ -83,4 +83,27 @@ class FireBaseRepositoryImpl @Inject constructor(
             throw Exception(e.message)
         }
     }
+
+    override suspend fun getFood(
+        ingredient: String,
+        onComplete: (List<IngredientType.Food>) -> Unit
+    ) {
+        userInfoDataSource.getUserInfo().addOnSuccessListener {
+            onComplete(
+                userMapper.mapToEntity((it.data?.get("foodInfo") as ArrayList<HashMap<String, *>>).map { result ->
+                    FoodDto(
+                        (result["id"] as String),
+                        ((result["foodId"] as Long).toInt()),
+                        (result["expirationDate"] as String),
+                        (result["name"] as String),
+                        (result["image"] as String?),
+                        ((result["categoryId"] as Long).toInt()),
+                        ((result["foodCount"] as Long).toInt())
+                    )
+                }).filter { item -> item.name == ingredient }
+            )
+        }.addOnFailureListener { e ->
+            throw Exception(e.message)
+        }
+    }
 }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/domain/repository/FireBaseRepository.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/domain/repository/FireBaseRepository.kt
@@ -12,4 +12,5 @@ interface FireBaseRepository {
     suspend fun getAllRecipe(onComplete: (List<RecipeEntity>) -> Unit)
     suspend fun getIngredientRecipe(ingredient: String, onComplete: (List<RecipeEntity>) -> Unit)
     suspend fun getFoodList(onComplete: (ArrayList<IngredientType>) -> Unit)
+    suspend fun getFood(ingredient: String, onComplete: (List<IngredientType.Food>) -> Unit)
 }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/domain/usecase/EnterRefrigeratorPageUseCase.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/domain/usecase/EnterRefrigeratorPageUseCase.kt
@@ -1,6 +1,5 @@
 package com.angdroid.refrigerator_manament.domain.usecase
 
-import androidx.lifecycle.LifecycleCoroutineScope
 import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow

--- a/app/src/main/java/com/angdroid/refrigerator_manament/domain/usecase/EnterRefrigeratorPageUseCaseImpl.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/domain/usecase/EnterRefrigeratorPageUseCaseImpl.kt
@@ -1,13 +1,15 @@
 package com.angdroid.refrigerator_manament.domain.usecase
 
-import android.util.Log
-import androidx.lifecycle.LifecycleCoroutineScope
 import com.angdroid.refrigerator_manament.application.App
 import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
 import com.angdroid.refrigerator_manament.domain.repository.FireBaseRepository
 import com.angdroid.refrigerator_manament.util.CategoryType
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class EnterRefrigeratorPageUseCaseImpl @Inject constructor(private val fireBaseRepository: FireBaseRepository) :

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailActivity.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailActivity.kt
@@ -2,9 +2,13 @@ package com.angdroid.refrigerator_manament.presentation.detail
 
 import android.os.Bundle
 import androidx.activity.viewModels
+import androidx.window.layout.WindowMetrics
+import androidx.window.layout.WindowMetricsCalculator
 import com.angdroid.refrigerator_manament.R
 import com.angdroid.refrigerator_manament.databinding.ActivityDetailBinding
 import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
+import com.angdroid.refrigerator_manament.presentation.detail.adapter.DetailIngredientListAdapter
+import com.angdroid.refrigerator_manament.presentation.detail.adapter.DetailListAdapter
 import com.angdroid.refrigerator_manament.presentation.util.BaseActivity
 import com.angdroid.refrigerator_manament.util.collectFlowWhenStarted
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,12 +18,18 @@ class DetailActivity : BaseActivity<ActivityDetailBinding>(R.layout.activity_det
 
     private val detailViewModel: DetailViewModel by viewModels()
     private lateinit var detailListAdapter: DetailListAdapter
+    private lateinit var ingredientDetailListAdapter: DetailIngredientListAdapter
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.lifecycleOwner = this
         binding.detailViewModel = detailViewModel
         detailListAdapter = DetailListAdapter()
+
+        val windowMetrics: WindowMetrics = WindowMetricsCalculator.getOrCreate().computeCurrentWindowMetrics(this)
+        ingredientDetailListAdapter = DetailIngredientListAdapter(windowMetrics)
+
         binding.rcRecipe.adapter = detailListAdapter
+        binding.rvIngredient.adapter = ingredientDetailListAdapter
         collectData()
         intent.getParcelableExtra<IngredientType.Food>("foodName").let { food ->
             if (food == null) {
@@ -43,7 +53,10 @@ class DetailActivity : BaseActivity<ActivityDetailBinding>(R.layout.activity_det
 
     private fun collectData() {
         collectFlowWhenStarted(detailViewModel.recipeList) {
-            detailListAdapter.submitList(it)
+             detailListAdapter.submitList(it)
+        }
+        collectFlowWhenStarted(detailViewModel.foodList) {
+            ingredientDetailListAdapter.submitList(it)
         }
     }
 }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailActivity.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import com.angdroid.refrigerator_manament.R
 import com.angdroid.refrigerator_manament.databinding.ActivityDetailBinding
+import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
 import com.angdroid.refrigerator_manament.presentation.util.BaseActivity
 import com.angdroid.refrigerator_manament.util.collectFlowWhenStarted
 import dagger.hilt.android.AndroidEntryPoint
@@ -20,11 +21,22 @@ class DetailActivity : BaseActivity<ActivityDetailBinding>(R.layout.activity_det
         detailListAdapter = DetailListAdapter()
         binding.rcRecipe.adapter = detailListAdapter
         collectData()
-        intent.getStringExtra("foodName").let {
-            if (it == null) {
+        intent.getParcelableExtra<IngredientType.Food>("foodName").let { food ->
+            if (food == null) {
                 detailViewModel.getAllRecipe()
             } else {
-                detailViewModel.getIngredientRecipe(it)
+                detailViewModel.selectItem.value = food
+                detailViewModel.getIngredientRecipe(food.name)
+            }
+        }
+
+        binding.appbarIngredientDetail.topAppbar.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.top_back -> {
+                    finish()
+                    true
+                }
+                else -> false
             }
         }
     }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailViewModel.kt
@@ -15,7 +15,9 @@ import javax.inject.Inject
 class DetailViewModel @Inject constructor(private val firebaseRepository: FireBaseRepository) :
     ViewModel() {
     private val _recipeList = MutableStateFlow<List<RecipeEntity>>(listOf())
+    private val _foodList = MutableStateFlow<List<IngredientType.Food>>(listOf())
     val recipeList get() = _recipeList
+    val foodList get() = _foodList
     val selectItem = MutableStateFlow<IngredientType.Food?>(null)
     fun getAllRecipe() {
         viewModelScope.launch {
@@ -31,6 +33,9 @@ class DetailViewModel @Inject constructor(private val firebaseRepository: FireBa
         viewModelScope.launch {
             firebaseRepository.getIngredientRecipe(ingredient) {
                 _recipeList.value = it
+            }
+            firebaseRepository.getFood(ingredient) {
+                _foodList.value = it.sortedBy { it.expirationDate }
             }
         }
     }

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/DetailViewModel.kt
@@ -3,6 +3,7 @@ package com.angdroid.refrigerator_manament.presentation.detail
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.angdroid.refrigerator_manament.domain.entity.RecipeEntity
+import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
 import com.angdroid.refrigerator_manament.domain.repository.FireBaseRepository
 import com.angdroid.refrigerator_manament.domain.repository.HomeRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,6 +16,7 @@ class DetailViewModel @Inject constructor(private val firebaseRepository: FireBa
     ViewModel() {
     private val _recipeList = MutableStateFlow<List<RecipeEntity>>(listOf())
     val recipeList get() = _recipeList
+    val selectItem = MutableStateFlow<IngredientType.Food?>(null)
     fun getAllRecipe() {
         viewModelScope.launch {
 
@@ -23,7 +25,8 @@ class DetailViewModel @Inject constructor(private val firebaseRepository: FireBa
             }
         }
     }
-    fun getIngredientRecipe(ingredient:String){
+
+    fun getIngredientRecipe(ingredient: String) {
 
         viewModelScope.launch {
             firebaseRepository.getIngredientRecipe(ingredient) {

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailIngredientListAdapter.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailIngredientListAdapter.kt
@@ -1,0 +1,46 @@
+package com.angdroid.refrigerator_manament.presentation.detail.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import android.view.ViewGroup.MarginLayoutParams
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import androidx.window.layout.WindowMetrics
+import com.angdroid.refrigerator_manament.BR
+import com.angdroid.refrigerator_manament.databinding.ItemIngredientDetailBinding
+import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
+import com.angdroid.refrigerator_manament.presentation.util.GlobalDiffCallBack
+import com.angdroid.refrigerator_manament.presentation.util.dpToPx
+
+class DetailIngredientListAdapter(private val windowMetrics: WindowMetrics) :
+    ListAdapter<IngredientType.Food, DetailIngredientListAdapter.IngredientViewHolder>(
+        GlobalDiffCallBack()
+    ) {
+
+    private lateinit var inflater: LayoutInflater
+
+
+    class IngredientViewHolder(val binding: ItemIngredientDetailBinding) : ViewHolder(binding.root)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IngredientViewHolder {
+        if (!::inflater.isInitialized) {
+            inflater = LayoutInflater.from(parent.context)
+        }
+        return IngredientViewHolder(ItemIngredientDetailBinding.inflate(inflater, parent, false))
+    }
+
+    override fun onBindViewHolder(holder: IngredientViewHolder, position: Int) {
+
+        (holder.binding.clRoot.layoutParams as ViewGroup.LayoutParams).apply {
+            if (position == 0) {
+                (this as MarginLayoutParams).marginStart =
+                    16.dpToPx(context = holder.binding.clRoot.context)
+            }
+            width =
+                (windowMetrics.bounds.width() - 44.dpToPx(holder.binding.clRoot.context)) / 2 // 양쪽 여백 + 사이 여백
+
+        }
+        holder.binding.setVariable(BR.food, getItem(position))
+    }
+
+}

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailRecipeListAdapter.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailRecipeListAdapter.kt
@@ -6,10 +6,8 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
 import com.angdroid.refrigerator_manament.BR
-import com.angdroid.refrigerator_manament.databinding.ItemIngredientDetailBinding
+import com.angdroid.refrigerator_manament.databinding.ItemRecipeDetailBinding
 import com.angdroid.refrigerator_manament.domain.entity.RecipeEntity
-import com.angdroid.refrigerator_manament.domain.entity.model.IngredientType
-import com.angdroid.refrigerator_manament.presentation.util.GlobalDiffCallBack
 
 class DetailListAdapter :
     ListAdapter<RecipeEntity, DetailListAdapter.DetailViewHolder>(DetailDiffCallBack) {

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailRecipeListAdapter.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/detail/adapter/DetailRecipeListAdapter.kt
@@ -1,4 +1,4 @@
-package com.angdroid.refrigerator_manament.presentation.detail
+package com.angdroid.refrigerator_manament.presentation.detail.adapter
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
@@ -13,14 +13,14 @@ class DetailListAdapter :
     ListAdapter<RecipeEntity, DetailListAdapter.DetailViewHolder>(DetailDiffCallBack) {
     private lateinit var inflater: LayoutInflater
 
-    class DetailViewHolder(val binding: ItemIngredientDetailBinding) : ViewHolder(binding.root)
+    class DetailViewHolder(val binding: ItemRecipeDetailBinding) : ViewHolder(binding.root)
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailViewHolder {
         if (!::inflater.isInitialized) {
             inflater = LayoutInflater.from(parent.context)
         }
         return DetailViewHolder(
-            ItemIngredientDetailBinding.inflate(inflater, parent, false)
+            ItemRecipeDetailBinding.inflate(inflater, parent, false)
         )
     }
 

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/home/fragment/RefrigeratorFragment.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/home/fragment/RefrigeratorFragment.kt
@@ -36,7 +36,7 @@ class RefrigeratorFragment :
                     requireContext(),
                     DetailActivity::class.java
                 ).apply {
-                    this.putExtra("foodName", item.name)
+                    this.putExtra("foodName", item)
                 })
         }
         binding.rvList.layoutManager =

--- a/app/src/main/java/com/angdroid/refrigerator_manament/presentation/util/ViewExtension.kt
+++ b/app/src/main/java/com/angdroid/refrigerator_manament/presentation/util/ViewExtension.kt
@@ -6,7 +6,6 @@ import android.widget.Toast
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import com.google.android.material.snackbar.Snackbar
-import com.google.android.material.snackbar.Snackbar.make
 
 fun View.makeSnackbar(messgae: String) {
     Snackbar.make(

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -5,6 +5,8 @@
 
     <data>
 
+        <import type="com.angdroid.refrigerator_manament.util.CategoryType" />
+
         <variable
             name="detailViewModel"
             type="com.angdroid.refrigerator_manament.presentation.detail.DetailViewModel" />
@@ -29,15 +31,65 @@
             android:orientation="vertical"
             app:layout_constraintGuide_end="@dimen/app_base_space" />
 
+        <include
+            android:id="@+id/appbar_ingredient_detail"
+            layout="@layout/layout_material_appbar"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+
+        <TextView
+            android:id="@+id/tv_ingredient_title"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@{detailViewModel.selectItem.name}"
+            android:textAppearance="@style/Widget.TextView.Pretendard24_Black_Bold.TextAppearance"
+            app:layout_constraintEnd_toEndOf="@id/gd_right"
+            app:layout_constraintStart_toStartOf="@id/gd_left"
+            app:layout_constraintTop_toBottomOf="@id/appbar_ingredient_detail"
+            tools:text="@string/category_vegetable" />
+
+        <TextView
+            android:id="@+id/tv_ingredient_category"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/sub_space_8"
+            android:text="@{CategoryType.INSTANCE.categoryStringList[detailViewModel.selectItem.categoryId-1]}"
+            android:textAppearance="@style/Widget.TextView.Pretendard13_Black_Medium.TextAppearance"
+            android:textColor="@color/gray2"
+            app:layout_constraintEnd_toEndOf="@id/gd_right"
+            app:layout_constraintStart_toStartOf="@id/gd_left"
+            app:layout_constraintTop_toBottomOf="@id/tv_ingredient_title"
+            tools:text="@string/category_fruit" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rv_ingredient"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/sub_space_24"
+            app:layout_constraintStart_toStartOf="@id/gd_left"
+            app:layout_constraintTop_toBottomOf="@id/tv_ingredient_category" />
+
+        <View
+            android:id="@+id/v_separator"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:layout_marginTop="@dimen/sub_space_24"
+            android:background="#EEEEEE"
+            app:layout_constraintEnd_toEndOf="@id/gd_right"
+            app:layout_constraintStart_toStartOf="@id/gd_left"
+            app:layout_constraintTop_toBottomOf="@+id/rv_ingredient" />
+
         <TextView
             android:id="@+id/tv_suggest_title"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/sub_space_24"
             android:text="@string/suggest_recipe"
             android:textAppearance="@style/Widget.TextView.Pretendard16_Black_Bold.TextAppearance"
             app:layout_constraintEnd_toEndOf="@id/gd_right"
             app:layout_constraintStart_toStartOf="@id/gd_left"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@+id/v_separator" />
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rc_recipe"

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -12,9 +12,12 @@
             type="com.angdroid.refrigerator_manament.presentation.detail.DetailViewModel" />
     </data>
 
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         tools:context=".presentation.detail.DetailActivity">
 
         <androidx.constraintlayout.widget.Guideline
@@ -97,11 +100,14 @@
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rc_recipe"
             android:layout_width="match_parent"
+            android:nestedScrollingEnabled="false"
             android:layout_height="wrap_content"
+            app:fastScrollEnabled="false"
             android:layout_marginTop="@dimen/sub_space_6"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toBottomOf="@+id/tv_suggest_title"
             tools:listitem="@layout/item_recipe_detail" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
 </layout>

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -67,8 +67,11 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/sub_space_24"
-            app:layout_constraintStart_toStartOf="@id/gd_left"
-            app:layout_constraintTop_toBottomOf="@id/tv_ingredient_category" />
+            android:orientation="horizontal"
+            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tv_ingredient_category"
+            tools:listitem="@layout/item_ingredient_detail" />
 
         <View
             android:id="@+id/v_separator"
@@ -98,7 +101,7 @@
             android:layout_marginTop="@dimen/sub_space_6"
             app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
             app:layout_constraintTop_toBottomOf="@+id/tv_suggest_title"
-            tools:listitem="@layout/item_ingredient_detail" />
+            tools:listitem="@layout/item_recipe_detail" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_ingredient_detail.xml
+++ b/app/src/main/res/layout/item_ingredient_detail.xml
@@ -1,81 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 
+        <import type="java.time.LocalDate" />
+
         <variable
-            name="recipeItem"
-            type="com.angdroid.refrigerator_manament.domain.entity.RecipeEntity" />
+            name="food"
+            type="com.angdroid.refrigerator_manament.domain.entity.model.IngredientType.Food" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-
-        android:layout_width="match_parent"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/cl_root"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="@dimen/sub_space_16"
-        android:layout_marginVertical="@dimen/sub_space_6">
+        android:layout_marginEnd="@dimen/sub_space_16">
 
-        <ImageView
-            android:id="@+id/iv_food"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cv_food"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:elevation="10dp"
+            app:cardCornerRadius="@dimen/sub_space_12"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:load_remote_coil_corner="@{recipeItem.image}"
-            tools:src="@drawable/apple" />
+            app:layout_constraintTop_toTopOf="parent">
+
+            <ImageView
+                android:id="@+id/iv_food"
+                android:layout_width="wrap_content"
+                android:layout_height="140dp"
+                android:scaleType="fitXY"
+                app:load_default_ingredient="@{food.name}"
+                tools:src="@drawable/apple" />
+        </androidx.cardview.widget.CardView>
 
         <TextView
-            android:id="@+id/tv_recipe_name"
+            android:id="@+id/tv_until_day"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/sub_space_12"
-            android:layout_marginTop="@dimen/sub_space_8"
-            android:text="@{recipeItem.name}"
+            android:layout_marginTop="@dimen/sub_space_12"
+            android:text="@{@string/until_day(LocalDate.now().dayOfMonth-food.expirationDate.dayOfMonth)}"
             android:textAppearance="@style/Widget.TextView.Pretendard15_Black_SemiBold.TextAppearance"
             android:textColor="@color/black_second"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/iv_food"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintEnd_toEndOf="@id/cv_food"
+            app:layout_constraintStart_toStartOf="@id/cv_food"
+            app:layout_constraintTop_toBottomOf="@id/cv_food" />
 
-        <ImageView
-            android:id="@+id/iv_time"
+        <TextView
+            android:id="@+id/tv_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:src="@drawable/ic_time"
-            app:layout_constraintStart_toStartOf="@+id/tv_recipe_name"
-            app:layout_constraintTop_toBottomOf="@id/tv_recipe_name"
-            app:tint="@color/gray2" />
+            android:layout_marginTop="@dimen/sub_space_8"
+            android:text="@{@string/food_count(food.foodCount)}"
+            android:textAppearance="@style/Widget.TextView.Pretendard12_Black_Regular.TextAppearance"
+            android:textColor="@color/gray1"
+            app:layout_constraintStart_toStartOf="@id/cv_food"
+            app:layout_constraintTop_toBottomOf="@+id/tv_until_day" />
 
         <TextView
-            android:id="@+id/tv_time"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
-            android:text="@{recipeItem.time}"
+            android:layout_marginStart="@dimen/sub_space_8"
+            android:layout_marginTop="@dimen/sub_space_8"
+            android:text="@{food.expirationDate.toString()}"
             android:textAppearance="@style/Widget.TextView.Pretendard12_Black_Regular.TextAppearance"
             android:textColor="@color/gray2"
-            app:layout_constraintBottom_toBottomOf="@+id/iv_time"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toEndOf="@+id/iv_time"
-            app:layout_constraintTop_toTopOf="@+id/iv_time" />
-
-        <!--TODO(BindingAdapter로 Span Text Color 적용해야함 일단 이렇게만 해둠-->
-        <TextView
-            android:id="@+id/tv_food_list"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="@dimen/sub_space_8"
-            android:bufferType="spannable"
-            android:ellipsize="end"
-            android:maxLines="1"
-            android:textAppearance="@style/Widget.TextView.Pretendard14_Black_Regular.TextAppearance"
-            android:textColor="@color/gray1"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="@id/tv_recipe_name"
-            app:necessary_ingredients="@{recipeItem.foodList}" />
+            app:layout_constraintBottom_toBottomOf="@+id/tv_count"
+            app:layout_constraintEnd_toEndOf="@id/cv_food"
+            app:layout_constraintStart_toEndOf="@+id/tv_count"
+            app:layout_constraintTop_toBottomOf="@+id/tv_until_day" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/item_recipe_detail.xml
+++ b/app/src/main/res/layout/item_recipe_detail.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="recipeItem"
+            type="com.angdroid.refrigerator_manament.domain.entity.RecipeEntity" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/sub_space_16"
+        android:layout_marginVertical="@dimen/sub_space_6">
+
+        <ImageView
+            android:id="@+id/iv_food"
+            android:layout_width="80dp"
+            android:layout_height="80dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:load_remote_coil_corner="@{recipeItem.image}"
+            tools:src="@drawable/apple" />
+
+        <TextView
+            android:id="@+id/tv_recipe_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/sub_space_12"
+            android:layout_marginTop="@dimen/sub_space_8"
+            android:text="@{recipeItem.name}"
+            android:textAppearance="@style/Widget.TextView.Pretendard15_Black_SemiBold.TextAppearance"
+            android:textColor="@color/black_second"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/iv_food"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/iv_time"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:src="@drawable/ic_time"
+            app:layout_constraintStart_toStartOf="@+id/tv_recipe_name"
+            app:layout_constraintTop_toBottomOf="@id/tv_recipe_name"
+            app:tint="@color/gray2" />
+
+        <TextView
+            android:id="@+id/tv_time"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="@{recipeItem.time}"
+            android:textAppearance="@style/Widget.TextView.Pretendard12_Black_Regular.TextAppearance"
+            android:textColor="@color/gray2"
+            app:layout_constraintBottom_toBottomOf="@+id/iv_time"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/iv_time"
+            app:layout_constraintTop_toTopOf="@+id/iv_time" />
+
+        <!--TODO(BindingAdapter로 Span Text Color 적용해야함 일단 이렇게만 해둠-->
+        <TextView
+            android:id="@+id/tv_food_list"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/sub_space_8"
+            android:bufferType="spannable"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textAppearance="@style/Widget.TextView.Pretendard14_Black_Regular.TextAppearance"
+            android:textColor="@color/gray1"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="@id/tv_recipe_name"
+            app:necessary_ingredients="@{recipeItem.foodList}" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/layout/layout_material_appbar.xml
+++ b/app/src/main/res/layout/layout_material_appbar.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <com.google.android.material.appbar.MaterialToolbar
         android:id="@+id/top_appbar"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,5 +42,7 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="suggest_recipe">💁🏻‍♀️ 추천 레시피</string>
+    <string name="until_day">%d일 남았어요</string>
+    <string name="food_count">%d개</string>
 
 </resources>


### PR DESCRIPTION
## 🎸 작업한 내용
- 시연용 뷰 완성했습니다.
- 선택한 재료에 대해서 count를 accumulator 적용하지 않은 데이터로 반환, 날짜순으로 정렬
- 이미지 불러오는건 수정이 필요함
- 아이템 크기가 화면 width/2 정도라서 margin 준거까지 계산해서 동적으로 변경하였습니다.
- 스크롤 처리 일단 NestedScrollView로 처리했는데, 나중에 변경할 것입니다.(Recycle이 되지 않음)
## 🎶 PR Point
<!-- 피드백을 받고 싶은 부분, 공유하고 싶은 부분, 작업 과정, 이유를 적어주세요. -->
- 네이밍을 좀 많이 바꿔야함
- UseCase 분리해야함
- 각 식재료별 default LocalDate가 필요함

## 📸 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 카톡 보내주세요. -->
<img width="303" alt="스크린샷 2022-10-23 오후 11 27 39" src="https://user-images.githubusercontent.com/15981307/197397676-daa80b73-8953-492c-aa0c-cdf2c1ba292a.png">

## 💽 관련 이슈
- Resolved: #29 

<!-- 아 맞다! Assignee, Reviewer 설정! 😇 -->
